### PR TITLE
M1.6.test(slice): add CRUD and selector tests for project.slices

### DIFF
--- a/docs/TESTPLAN.md
+++ b/docs/TESTPLAN.md
@@ -106,7 +106,7 @@ Use `vi.mock` to stub projectService methods and validate parameters.
 
 #### 🧩 Project Slice
 
-**Scope:** projectsSlice
+**Scope:** project.slice
 
 **Description:**
 Test Redux slice reducers and selectors (`selectAll`, `selectById`, `selectByName`).

--- a/src/entities/project/model/__tests__/project.slice.test.ts
+++ b/src/entities/project/model/__tests__/project.slice.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { configureStore } from '@reduxjs/toolkit';
+import {
+	createProject,
+	deleteProject,
+	fetchProjects,
+	makeSelectors,
+	projectsReducer,
+	updateProject,
+} from '../slice';
+import { projectRepository } from '../../api/project.repository';
+import { nanoid } from 'nanoid';
+import type { Project } from '@/shared/types';
+import { db } from '@/shared/lib/db/dexie.ts';
+
+type Root = ReturnType<ReturnType<typeof storeFactory>['getState']>;
+
+const storeFactory = () =>
+	configureStore({
+		reducer: { projects: projectsReducer },
+	});
+
+const selectorsFactory = () => makeSelectors<Root>((s) => s.projects);
+
+describe('projectsSlice + thunks', () => {
+	beforeEach(async () => {
+		await db.projects.clear();
+	});
+
+	it('fetchProjects populates state from IndexedDB', async () => {
+		const now = Date.now();
+		const records: Project[] = [
+			{ id: nanoid(), name: 'A', createdAt: now - 2, updatedAt: now - 2 },
+			{ id: nanoid(), name: 'B', createdAt: now - 1, updatedAt: now - 1 },
+		];
+		for (const r of records) await projectRepository.add(r);
+
+		const store = storeFactory();
+		const selectors = selectorsFactory();
+
+		await store.dispatch(fetchProjects());
+		const all = selectors.selectAll(store.getState());
+		expect(all.length).toBe(2);
+		expect(all.map((x) => x.name)).toEqual(['B', 'A']);
+	});
+
+	it('createProject adds a project to the state', async () => {
+		const store = storeFactory();
+		const selectors = selectorsFactory();
+
+		await store.dispatch(createProject({ name: 'Demo' }));
+
+		const all = selectors.selectAll(store.getState());
+		expect(all.length).toBe(1);
+		expect(all[0]?.name).toBe('Demo');
+	});
+
+	it('updateProject updates a project', async () => {
+		const store = storeFactory();
+		const selectors = selectorsFactory();
+
+		const createRes = await store.dispatch(createProject({ name: 'X' })).unwrap();
+		await store.dispatch(updateProject({ id: createRes.id, changes: { name: 'Y' } }));
+
+		const byId = selectors.selectById(store.getState(), createRes.id);
+		expect(byId?.name).toBe('Y');
+	});
+
+	it('deleteProject removes a project', async () => {
+		const store = storeFactory();
+		const selectors = selectorsFactory();
+
+		const p = await store.dispatch(createProject({ name: 'ToDelete' })).unwrap();
+		await store.dispatch(deleteProject(p.id));
+
+		const exists = selectors.selectById(store.getState(), p.id);
+		expect(exists).toBeUndefined();
+	});
+
+	it('selectByName filters by name, case-insensitively', async () => {
+		const store = storeFactory();
+		const selectors = selectorsFactory();
+
+		await store.dispatch(createProject({ name: 'My Project' }));
+		await store.dispatch(createProject({ name: 'Another' }));
+
+		const filtered = selectors.selectByName(store.getState(), 'project');
+		expect(filtered.map((x) => x.name)).toEqual(['My Project']);
+	});
+});

--- a/src/shared/lib/store/__tests__/createAsyncEntitySlice.test.ts
+++ b/src/shared/lib/store/__tests__/createAsyncEntitySlice.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createAsyncEntitySlice } from '../createAsyncEntitySlice';
+import { PROJECT_MESSAGES } from '@/shared/constants/projectMessages.ts';
+
+describe('createAsyncEntitySlice', () => {
+	const fetchAll = vi.fn(async () => [{ id: '1', name: 'Alpha' }]);
+	const createOne = vi.fn(async (data: { name: string }) => ({
+		id: '2',
+		name: data.name,
+	}));
+	const updateOne = vi.fn(async (data: { id: string; name: string }) => data);
+	const deleteOne = vi.fn(async () => undefined);
+
+	const slice = createAsyncEntitySlice({
+		name: 'test',
+		fetchAll,
+		createOne,
+		updateOne,
+		deleteOne,
+	});
+
+	const { reducer, thunks, makeSelectors } = slice;
+
+	it('should handle pending action correctly', () => {
+		const prevState = reducer(undefined, { type: 'unknown' });
+		const nextState = reducer(prevState, {
+			type: thunks.createOneThunk.pending.type,
+		});
+		expect(nextState.loading).toBe('pending');
+	});
+
+	it('should set error and failed state on rejected actions', () => {
+		const errorAction = {
+			type: thunks.fetchAllThunk.rejected.type,
+			error: { message: 'Boom!' },
+		};
+		const state = reducer(undefined, errorAction);
+		expect(state.loading).toBe('failed');
+		expect(state.error).toBe('Boom!');
+	});
+
+	it('should clear error when clearError is called', () => {
+		const erroredState = {
+			ids: [],
+			entities: {},
+			loading: 'failed' as const,
+			error: 'Oops',
+		};
+		const action = { type: slice.actions.clearError.type };
+		const newState = reducer(erroredState, action);
+		expect(newState.error).toBeNull();
+	});
+
+	it('selectByName should return filtered entities', () => {
+		const fakeState = {
+			test: {
+				ids: ['1', '2'],
+				entities: {
+					'1': { id: '1', name: 'Alpha' },
+					'2': { id: '2', name: 'Beta' },
+				},
+				loading: 'idle' as const,
+				error: null,
+			},
+		};
+
+		const selectors = makeSelectors((s: typeof fakeState) => s.test);
+		const result = selectors.selectByName(fakeState, 'alp');
+		expect(result).toEqual([{ id: '1', name: 'Alpha' }]);
+	});
+	it('should use default error message if error.message is undefined', () => {
+		const action = {
+			type: thunks.fetchAllThunk.rejected.type,
+			error: {},
+		};
+		const state = reducer(undefined, action);
+		expect(state.error).toBe(PROJECT_MESSAGES.ERROR_ACTION);
+	});
+
+	it('selectByName should handle items without name field', () => {
+		const fakeState = {
+			test: {
+				ids: ['1', '2'],
+				entities: {
+					'1': { id: '1' }, // no name
+					'2': { id: '2', name: 'Alpha' },
+				},
+				loading: 'idle' as const,
+				error: null,
+			},
+		};
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const selectors = makeSelectors((s: any) => s.test);
+
+		const result = selectors.selectByName(fakeState, 'alp');
+		expect(result).toEqual([{ id: '2', name: 'Alpha' }]);
+	});
+});


### PR DESCRIPTION
### 📌 Pull Request

#### 🔀 Branch

`test/project-slice`

#### 📝 Description

test(slice): add CRUD and selector tests for project.slices

#### ✅ Related Issue

Closes #51 

#### 🔍 Checklist

- [x] test project.slice.ts
- [x] test  createAsyncEntitySlice.ts

