### PR TITLE
M2.fix(projects): set length of input create/update modal to 25 symbols/zod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
 				"react-dom": "19.1.1",
 				"react-redux": "9.2.0",
 				"react-router-dom": "7.9.4",
-				"redux-logger": "3.0.6"
+				"redux-logger": "3.0.6",
+				"zod": "4.1.12"
 			},
 			"devDependencies": {
 				"@eslint/js": "9.36.0",
@@ -8937,6 +8938,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zod": {
+			"version": "4.1.12",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+			"integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
 		"react-dom": "19.1.1",
 		"react-redux": "9.2.0",
 		"react-router-dom": "7.9.4",
-		"redux-logger": "3.0.6"
+		"redux-logger": "3.0.6",
+		"zod": "4.1.12"
 	},
 	"devDependencies": {
 		"@eslint/js": "9.36.0",

--- a/src/entities/project/model/__tests__/project.service.test.ts
+++ b/src/entities/project/model/__tests__/project.service.test.ts
@@ -11,7 +11,7 @@ describe('projectService', () => {
 
 	it('should throw an error if name is empty', async () => {
 		await expect(projectService.createProject({ name: '   ' })).rejects.toThrow(
-			PROJECT_MESSAGES.EMPTY_NAME,
+			PROJECT_MESSAGES.NAME_EMPTY,
 		);
 	});
 

--- a/src/entities/project/model/project.service.ts
+++ b/src/entities/project/model/project.service.ts
@@ -10,7 +10,7 @@ export const projectService = {
 
 	async createProject(data: { name: string }): Promise<Project> {
 		const name = data.name.trim();
-		if (!name) throw new Error(PROJECT_MESSAGES.EMPTY_NAME);
+		if (!name) throw new Error(PROJECT_MESSAGES.NAME_EMPTY);
 
 		const exists = await projectRepository.findByName(name);
 		if (exists) throw new Error(PROJECT_MESSAGES.DUPLICATE_NAME);

--- a/src/entities/project/ui/_shared/__tests__/ProjectModalBase.test.tsx
+++ b/src/entities/project/ui/_shared/__tests__/ProjectModalBase.test.tsx
@@ -1,7 +1,7 @@
-import { screen, fireEvent, waitFor } from '@testing-library/react';
-import { renderWithStore } from '@/test-utils';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { ProjectModalBase } from '../ProjectModalBase';
 import { PROJECT_MESSAGES } from '@/shared/constants';
+import { renderWithStore } from '@/test-utils';
 import { vi } from 'vitest';
 
 describe('ProjectModalBase', () => {
@@ -27,7 +27,7 @@ describe('ProjectModalBase', () => {
 	it('shows validation error when input is empty', async () => {
 		await renderModal();
 		fireEvent.click(await screen.findByTestId('project-submit'));
-		expect(await screen.findByText(PROJECT_MESSAGES.EMPTY_NAME)).toBeInTheDocument();
+		expect(await screen.findByText(PROJECT_MESSAGES.NAME_EMPTY)).toBeInTheDocument();
 	});
 
 	it('handles successful submit', async () => {

--- a/src/entities/project/ui/_shared/__tests__/projectModalBase.validation.test.tsx
+++ b/src/entities/project/ui/_shared/__tests__/projectModalBase.validation.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { ProjectModalBase } from '../ProjectModalBase';
+import { PROJECT_MESSAGES } from '@/shared/constants';
+import { renderWithStore } from '@/test-utils';
+import { vi } from 'vitest';
+
+describe('ProjectModalBase validation', () => {
+	it('shows error when input is empty', async () => {
+		const onClose = vi.fn();
+		const onSubmitAction = vi.fn();
+
+		renderWithStore(
+			<ProjectModalBase
+				title="Test Modal"
+				buttonLabel="Create"
+				onClose={onClose}
+				onSubmitAction={onSubmitAction}
+				buildArgs={(name) => ({ name })}
+			/>,
+		);
+
+		fireEvent.submit(screen.getByTestId('project-form'));
+
+		expect(await screen.findByRole('alert')).toHaveTextContent(
+			PROJECT_MESSAGES.NAME_EMPTY,
+		);
+	});
+
+	it('shows error if name exceeds 25 characters', async () => {
+		const onClose = vi.fn();
+		const onSubmitAction = vi.fn();
+
+		renderWithStore(
+			<ProjectModalBase
+				title="Test Modal"
+				buttonLabel="Create"
+				onClose={onClose}
+				onSubmitAction={onSubmitAction}
+				buildArgs={(name) => ({ name })}
+			/>,
+		);
+
+		const input = screen.getByTestId('project-input');
+		fireEvent.change(input, { target: { value: 'A'.repeat(26) } });
+		fireEvent.submit(screen.getByTestId('project-form'));
+
+		expect(await screen.findByRole('alert')).toHaveTextContent(
+			PROJECT_MESSAGES.NAME_REQUEST,
+		);
+	});
+});

--- a/src/shared/constants/projectMessages.ts
+++ b/src/shared/constants/projectMessages.ts
@@ -1,6 +1,7 @@
 export const PROJECT_MESSAGES = {
 	ERROR_ACTION: 'Error during an action',
-	EMPTY_NAME: 'Project name cannot be empty',
+	NAME_EMPTY: 'Project name is required',
+	NAME_REQUEST: 'Project name must be at most 25 characters long',
 	DUPLICATE_NAME: 'A project with this name already exists',
 	NOT_FOUND_AFTER_UPDATE: 'Project not found after update',
 	UNEXPECTED_SERVER_ERROR: 'Unexpected server error',

--- a/src/shared/schema/index.ts
+++ b/src/shared/schema/index.ts
@@ -1,0 +1,1 @@
+export * from './projectNameSchema.ts';

--- a/src/shared/schema/projectNameSchema.ts
+++ b/src/shared/schema/projectNameSchema.ts
@@ -1,0 +1,8 @@
+import { PROJECT_MESSAGES } from '@/shared/constants';
+import { z } from 'zod';
+
+export const projectNameSchema = z
+	.string()
+	.trim()
+	.min(1, PROJECT_MESSAGES.NAME_EMPTY)
+	.max(25, PROJECT_MESSAGES.NAME_REQUEST);

--- a/src/test-utils/renderWithStore.tsx
+++ b/src/test-utils/renderWithStore.tsx
@@ -1,26 +1,19 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
-import { makeTestStore } from '@/test-utils/testStore';
-import type { RootState } from '@/store';
+import { type TestRootState, TestStoreProvider } from '@/test-utils';
 
 /**
  * Renders a React component inside Redux + Router context.
  * Returns both the store and testing-library utilities.
- *
- * If DOM stays empty (e.g., modal didn't render), it logs a snapshot automatically.
  */
-export function renderWithStore<S extends Partial<RootState> = Partial<RootState>>(
+export function renderWithStore(
 	ui: React.ReactElement,
-	{ initialState }: { initialState?: S } = {},
+	options?: { initialState?: Partial<TestRootState> },
 ) {
-	const store = makeTestStore(initialState);
-	const utils = render(
-		<Provider store={store}>
+	return render(
+		<TestStoreProvider initialState={options?.initialState}>
 			<MemoryRouter>{ui}</MemoryRouter>
-		</Provider>,
+		</TestStoreProvider>,
 	);
-
-	return { store, ...utils };
 }


### PR DESCRIPTION
### 📌 Pull Request

#### 🔀 Branch

`home/fix/project-modal-input-length`

#### 📝 Description

Set length of input create/update modal to 25 symbols. Install  the zod. Create project input schema validation.

#### ✅ Related Issue

Closes #77 

#### 🔍 Checklist

- [x] Install the zod
- [x] update form with the zod
- [x]  create validation schema for input modal
- [x]  create test for validation input modals

