### PR TITLE
M4.feat(layers): add full layer management with Dexie

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "editor",
 	"private": true,
-	"version": "1.0.0-beta.13",
+	"version": "1.0.0-beta.14",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/src/App.css
+++ b/src/App.css
@@ -4,3 +4,7 @@ html, body, #root {
 	height: 100%;
 	margin: 0;
 }
+
+.cursor-grab, .cursor-grabbing {
+	transition: cursor 0.15s ease;
+}

--- a/src/entities/brush/model/slice.ts
+++ b/src/entities/brush/model/slice.ts
@@ -25,8 +25,10 @@ const brushSlice = createSlice({
 		setBrushDrawing(state, action: PayloadAction<boolean>) {
 			state.isDrawing = action.payload;
 		},
+		resetBrushState: () => initialState,
 	},
 });
 
-export const { setBrushColor, setBrushSize, setBrushDrawing } = brushSlice.actions;
+export const { setBrushColor, setBrushSize, setBrushDrawing, resetBrushState } =
+	brushSlice.actions;
 export const brushReducer = brushSlice.reducer;

--- a/src/entities/editor/model/slice.ts
+++ b/src/entities/editor/model/slice.ts
@@ -35,13 +35,11 @@ const editorSlice = createSlice({
 			}
 		},
 
-		closePalette(state) {
-			state.paletteOpen = false;
-		},
+		resetEditorState: () => initialState,
 	},
 });
 
-export const { setScale, setOffset, resetViewport, setActiveTool, closePalette } =
+export const { setScale, setOffset, resetViewport, setActiveTool, resetEditorState } =
 	editorSlice.actions;
 
 export const editorReducer = editorSlice.reducer;

--- a/src/entities/eraser/hooks/useEraserDraw.ts
+++ b/src/entities/eraser/hooks/useEraserDraw.ts
@@ -1,15 +1,61 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { useAppSelector } from '@/store/hooks';
 import { strokeWidth, toCanvasPoint } from '@/shared/lib/utils';
 import { selectViewport } from '@/entities/editor/model/selectors';
 
-export function useEraserDraw(canvasRef: React.RefObject<HTMLCanvasElement | null>) {
+/**
+ * Eraser tool — erases pixels directly on the active layer.
+ * Includes live size indicator (cursor circle).
+ */
+export function useEraserDraw(getActiveCanvas: () => HTMLCanvasElement | null) {
 	const size = useAppSelector((s) => s.eraser.size);
 	const { scale: viewportScale } = useAppSelector(selectViewport);
 	const drawing = useRef(false);
 	const last = useRef<{ x: number; y: number } | null>(null);
-	const dpr = 1;
+	const dpr = window.devicePixelRatio ?? 1;
 
+	// Cursor indicator (mini overlay circle)
+	useEffect(() => {
+		const canvas = getActiveCanvas();
+		if (!canvas) return;
+		canvas.style.cursor = 'none'; // hide system cursor
+
+		const ctx = canvas.getContext('2d');
+		if (!ctx) return;
+
+		const handleMove = (e: MouseEvent) => {
+			if (!canvas) return;
+			const rect = canvas.getBoundingClientRect();
+			const x = e.clientX - rect.left;
+			const y = e.clientY - rect.top;
+
+			// draw small cursor ring
+			ctx.save();
+			ctx.clearRect(0, 0, canvas.width, canvas.height);
+			ctx.beginPath();
+			ctx.arc(x, y, (size * dpr) / 2, 0, Math.PI * 2);
+			ctx.strokeStyle = 'rgba(59,130,246,0.8)'; // blue ring
+			ctx.lineWidth = 1.2 * dpr;
+			ctx.stroke();
+			ctx.restore();
+		};
+
+		const handleLeave = () => {
+			if (!canvas) return;
+			const ctx2 = canvas.getContext('2d');
+			ctx2?.clearRect(0, 0, canvas.width, canvas.height);
+		};
+
+		canvas.addEventListener('mousemove', handleMove);
+		canvas.addEventListener('mouseleave', handleLeave);
+		return () => {
+			canvas.removeEventListener('mousemove', handleMove);
+			canvas.removeEventListener('mouseleave', handleLeave);
+			canvas.style.cursor = 'crosshair';
+		};
+	}, [getActiveCanvas, size, dpr]);
+
+	// ─── Core stroke logic ─────────────────────────────
 	const stroke = useCallback(
 		(
 			ctx: CanvasRenderingContext2D,
@@ -20,7 +66,6 @@ export function useEraserDraw(canvasRef: React.RefObject<HTMLCanvasElement | nul
 			ctx.globalCompositeOperation = 'destination-out';
 			ctx.lineCap = 'round';
 			ctx.lineJoin = 'round';
-			ctx.strokeStyle = 'rgba(0,0,0,1)';
 			ctx.lineWidth = strokeWidth(size, viewportScale, 'screen');
 			ctx.beginPath();
 			ctx.moveTo(a.x, a.y);
@@ -33,30 +78,30 @@ export function useEraserDraw(canvasRef: React.RefObject<HTMLCanvasElement | nul
 
 	const onPointerDown = useCallback(
 		(e: React.PointerEvent<HTMLCanvasElement>) => {
-			const canvas = canvasRef.current;
-			const ctx = canvas?.getContext('2d');
-			if (!ctx || !canvas) return;
-
+			const canvas = getActiveCanvas();
+			if (!canvas) return;
+			const ctx = canvas.getContext('2d');
+			if (!ctx) return;
 			const p = toCanvasPoint(e, canvas, { dpr });
 			drawing.current = true;
 			last.current = p;
 			stroke(ctx, p, p);
 		},
-		[canvasRef, stroke],
+		[dpr, getActiveCanvas, stroke],
 	);
 
 	const onPointerMove = useCallback(
 		(e: React.PointerEvent<HTMLCanvasElement>) => {
-			if (!drawing.current || !canvasRef.current) return;
-			const canvas = canvasRef.current;
+			if (!drawing.current) return;
+			const canvas = getActiveCanvas();
+			if (!canvas) return;
 			const ctx = canvas.getContext('2d');
 			if (!ctx || !last.current) return;
-
 			const p = toCanvasPoint(e, canvas, { dpr });
 			stroke(ctx, last.current, p);
 			last.current = p;
 		},
-		[canvasRef, stroke],
+		[dpr, getActiveCanvas, stroke],
 	);
 
 	const onPointerUp = useCallback(() => {

--- a/src/entities/eraser/model/slice.ts
+++ b/src/entities/eraser/model/slice.ts
@@ -17,8 +17,9 @@ const eraserSlice = createSlice({
 		setEraserSize(state, action: PayloadAction<number>) {
 			state.size = action.payload;
 		},
+		resetEraserState: () => initialState,
 	},
 });
 
-export const { setEraserSize } = eraserSlice.actions;
+export const { setEraserSize, resetEraserState } = eraserSlice.actions;
 export const eraserReducer = eraserSlice.reducer;

--- a/src/entities/layer/model/index.ts
+++ b/src/entities/layer/model/index.ts
@@ -1,3 +1,3 @@
 export * from './slice';
-export * from './selectors';
 export * from './service';
+export * from './useLayerCanvases';

--- a/src/entities/layer/model/selectors.ts
+++ b/src/entities/layer/model/selectors.ts
@@ -1,18 +1,53 @@
+import { createSelector } from '@reduxjs/toolkit';
 import type { RootState } from '@/store';
-import { layersAdapter } from '@/entities/layer/model/slice';
+import { layersAdapter } from './slice';
 
+/**
+ * Base adapter selectors for layers entity.
+ */
+const baseSelectors = layersAdapter.getSelectors((s: RootState) => s.layers);
+
+/**
+ * Returns all layers (unfiltered).
+ * Useful for debugging or global counts.
+ */
+const selectAllLayers = baseSelectors.selectAll;
+
+/**
+ * Memoized selector factory — returns a stable array of layers
+ * belonging to the given projectId. Prevents unnecessary re-renders.
+ *
+ * Usage:
+ *   const selectByProject = useMemo(makeSelectByProject, []);
+ *   const layers = useAppSelector((s) => selectByProject(s, projectId));
+ */
+export const makeSelectByProject = () =>
+	createSelector(
+		[selectAllLayers, (_: RootState, projectId: string) => projectId],
+		(layers, projectId) => layers.filter((l) => l.projectId === projectId),
+	);
+
+/**
+ * Memoized global selectors for layers slice.
+ */
 export const layersSelectors = {
-	...layersAdapter.getSelectors((s: RootState) => s.layers),
+	...baseSelectors,
 
 	selectLoading: (s: RootState) => s.layers.loading,
 	selectError: (s: RootState) => s.layers.error,
 
-	selectActiveLayer: (s: RootState) =>
-		s.layers.entities[s.layers.activeId ?? ''] ?? null,
+	/**
+	 * Returns the currently active layer or null if none is selected.
+	 * Stable reference — won't trigger re-render if unchanged.
+	 */
+	selectActiveLayer: createSelector(
+		[(s: RootState) => s.layers.activeId, (s: RootState) => s.layers.entities],
+		(activeId, entities) => (activeId ? (entities[activeId] ?? null) : null),
+	),
 
+	/**
+	 * Simple non-memoized version (fallback) — not recommended for large projects.
+	 */
 	selectByProject: (s: RootState, projectId: string) =>
-		layersAdapter
-			.getSelectors((state: RootState) => state.layers)
-			.selectAll(s)
-			.filter((l) => l.projectId === projectId),
+		baseSelectors.selectAll(s).filter((l) => l.projectId === projectId),
 };

--- a/src/entities/layer/model/useLayerCanvases.ts
+++ b/src/entities/layer/model/useLayerCanvases.ts
@@ -1,0 +1,62 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { Layer } from '@/shared/types';
+import { layerService } from '@/entities/layer/model';
+
+/**
+ * Manages DOM canvases for layers.
+ * - bindCanvasRef(id) binds a real <canvas> element to this layer
+ * - when mounted, restores a snapshot if it exists
+ * - when unmounted, saves all snapshots to Dexie
+ */
+export function useLayerCanvases(
+	layers: Layer[],
+	projectId: string,
+	width: number,
+	height: number,
+) {
+	const canvases = useRef<Map<string, HTMLCanvasElement>>(new Map());
+
+	// Binds DOM <canvas> to layer id
+	const bindCanvasRef = useMemo(
+		() => (id: string) => (el: HTMLCanvasElement | null) => {
+			if (!el) return;
+			canvases.current.set(id, el);
+
+			// ensure proper canvas dimensions
+			if (el.width !== width) el.width = width;
+			if (el.height !== height) el.height = height;
+
+			// restore snapshot if present
+			const layer = layers.find((l) => l.id === id);
+			if (layer?.snapshot) {
+				const img = new Image();
+				img.src = layer.snapshot;
+				img.onload = () => el.getContext('2d')?.drawImage(img, 0, 0);
+			}
+		},
+		[layers, width, height],
+	);
+
+	// Update all canvas dimensions when width/height changes
+	useEffect(() => {
+		for (const c of canvases.current.values()) {
+			if (c.width !== width) c.width = width;
+			if (c.height !== height) c.height = height;
+		}
+	}, [width, height]);
+
+	// Save all snapshots when component unmounts
+	useEffect(() => {
+		const mapSnapshot = canvases.current;
+		return () => {
+			for (const [id, canvas] of mapSnapshot.entries()) {
+				const snapshot = canvas.toDataURL('image/png');
+				void layerService.updateLayer({ id, changes: { snapshot } });
+			}
+		};
+	}, [projectId]);
+
+	const getCanvas = (id: string) => canvases.current.get(id) ?? null;
+
+	return { bindCanvasRef, getCanvas };
+}

--- a/src/entities/layer/ui/__tests__/LayersPanel.test.tsx
+++ b/src/entities/layer/ui/__tests__/LayersPanel.test.tsx
@@ -1,24 +1,51 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { forwardRef } from 'react';
 import * as hooks from '@/store/hooks';
-import type { AppDispatch } from '@/store';
+import type { AppDispatch, RootState } from '@/store';
 import type { Layer } from '@/shared/types';
 import { LayersPanel } from '@/entities/layer/ui';
-import { createLayer, fetchLayersByProject } from '@/entities/layer/model';
 
-// ─────────────────────────────── MOCK COMPONENTS ───────────────────────────────
 vi.mock('@/entities/layer/ui/components', () => {
 	type ToggleProps = { open: boolean; setOpen: (open: boolean) => void };
+	type OpacityProps = {
+		activeLayer: Layer | null;
+		onOpacityChange: (id: string, value: number) => void;
+	};
+	interface LayerItemProps {
+		layer: Layer;
+		isActive: boolean;
+		isEditing: boolean;
+		openMenuId: string | null;
+		onSetActive: (id: string) => void;
+		onToggleVisibility: (id: string, visible: boolean) => void;
+		onRenameSubmit: (id: string, name: string) => void;
+		onDelete: (id: string) => void;
+		setLocalNameId: (id: string | null) => void;
+		setOpenMenuId: (id: string | null) => void;
+	}
+
 	return {
 		AddLayerButton: ({ onCreate }: { onCreate: () => void }) => (
 			<button data-testid="mock-add-layer-btn" onClick={onCreate}>
-				Mock AddLayerButton
+				Add Layer
 			</button>
 		),
-		LayerItem: () => <li data-testid="mock-layer-item">Mock LayerItem</li>,
-		OpacitySlider: () => (
-			<div data-testid="mock-opacity-slider">Mock OpacitySlider</div>
+
+		LayerItem: forwardRef<HTMLDivElement, LayerItemProps>(
+			({ layer, isActive }, ref) => (
+				<div ref={ref} data-testid="mock-layer-item" data-layer-id={layer.id}>
+					{layer.name} {isActive && '(active)'}
+				</div>
+			),
 		),
+
+		OpacitySlider: ({ activeLayer }: OpacityProps) => (
+			<div data-testid="mock-opacity-slider">
+				Opacity: {activeLayer ? activeLayer.opacity : 'N/A'}
+			</div>
+		),
+
 		PanelToggleButton: ({ open, setOpen }: ToggleProps) => (
 			<button
 				type="button"
@@ -26,119 +53,275 @@ vi.mock('@/entities/layer/ui/components', () => {
 				aria-label={open ? 'Close Layers Panel' : 'Open Layers Panel'}
 				onClick={() => setOpen(!open)}
 			>
-				Mock Toggle
+				{open ? 'Close' : 'Open'} Panel
 			</button>
 		),
 	};
 });
 
-// ─────────────────────────────── MOCK HOOKS ───────────────────────────────
-vi.mock('@/store/hooks', async (importActual) => {
-	const actual = await importActual<typeof hooks>();
-	return {
-		...actual,
-		useAppDispatch: vi.fn(),
-		useAppSelector: vi.fn(),
-	};
-});
+vi.mock('@/store/hooks', () => ({
+	useAppDispatch: vi.fn(),
+	useAppSelector: vi.fn(),
+}));
 
 vi.mock('@/entities/layer/model/slice', () => ({
-	createLayer: vi.fn(() => ({ type: 'mock/createLayer' })),
-	deleteLayer: vi.fn(() => ({ type: 'mock/deleteLayer' })),
-	updateLayer: vi.fn((payload: unknown) => ({
-		type: 'mock/updateLayer',
+	createLayer: vi.fn((payload: { projectId: string }) => ({
+		type: 'layers/createLayer',
+		payload,
+	})),
+	deleteLayer: vi.fn((id: string) => ({
+		type: 'layers/deleteLayer',
+		payload: id,
+	})),
+	updateLayer: vi.fn((payload: { id: string; changes: Partial<Layer> }) => ({
+		type: 'layers/updateLayer',
 		payload,
 	})),
 	setActiveLayerId: vi.fn((id: string) => ({
-		type: 'mock/setActiveLayer',
+		type: 'layers/setActiveLayerId',
 		payload: id,
 	})),
 	fetchLayersByProject: vi.fn((projectId: string) => ({
-		type: 'mock/fetchLayers',
+		type: 'layers/fetchLayersByProject',
 		payload: projectId,
 	})),
 }));
 
-vi.mock('@/entities/layer/model/selectors', () => ({
-	layersSelectors: {
-		selectAll: { name: 'selectAll' },
-		selectActiveLayer: { name: 'selectActiveLayer' },
-	},
-}));
+vi.mock('@/entities/layer/model/selectors', () => {
+	const createMockLayers = (): Layer[] => [
+		{
+			id: 'layer-1',
+			name: 'Background',
+			visible: true,
+			opacity: 1,
+			zIndex: 0,
+			projectId: 'project-123',
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		},
+		{
+			id: 'layer-2',
+			name: 'Foreground',
+			visible: true,
+			opacity: 0.8,
+			zIndex: 1,
+			projectId: 'project-123',
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		},
+	];
 
-// ─────────────────────────────── MOCK DATA ───────────────────────────────
-const mockDispatch: AppDispatch = vi.fn() as unknown as AppDispatch;
-const mockSetIsOpen = vi.fn();
+	type SelectorFunc<TResult> = (state: RootState, ...args: string[]) => TResult;
+
+	const createMockSelector = <TResult,>(
+		impl: SelectorFunc<TResult>,
+	): SelectorFunc<TResult> => {
+		const selector = (state: RootState, ...args: string[]): TResult => {
+			return impl(state, ...args);
+		};
+
+		Object.assign(selector, {
+			resultFunc: impl,
+			recomputations: vi.fn(() => 0),
+			resetRecomputations: vi.fn(),
+		});
+
+		return selector;
+	};
+
+	const mockSelectByProjectInstance = createMockSelector<Layer[]>(
+		(_state: RootState, projectId: string) => {
+			const layers = createMockLayers();
+			return layers.filter((l) => l.projectId === projectId);
+		},
+	);
+
+	const mockSelectActiveLayer = createMockSelector<Layer | null>((state: RootState) => {
+		const activeId = state.layers?.activeId;
+		if (!activeId) return null;
+		const layers = createMockLayers();
+		return layers.find((l) => l.id === activeId) ?? null;
+	});
+
+	return {
+		layersSelectors: {
+			selectAll: vi.fn(),
+			selectActiveLayer: mockSelectActiveLayer,
+			selectLoading: vi.fn(),
+			selectError: vi.fn(),
+			selectByProject: vi.fn(),
+		},
+		makeSelectByProject: vi.fn(() => mockSelectByProjectInstance),
+	};
+});
 
 const mockLayers: Layer[] = [
 	{
-		id: '1',
+		id: 'layer-1',
 		name: 'Background',
 		visible: true,
 		opacity: 1,
 		zIndex: 0,
-		projectId: '123',
-		createdAt: new Date('2025-10-30').getTime(),
-		updatedAt: new Date('2025-10-30').getTime(),
+		projectId: 'project-123',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
 	},
 	{
-		id: '2',
+		id: 'layer-2',
 		name: 'Foreground',
-		visible: false,
-		opacity: 0.6,
+		visible: true,
+		opacity: 0.8,
 		zIndex: 1,
-		projectId: '123',
-		createdAt: new Date('2025-10-30').getTime(),
-		updatedAt: new Date('2025-10-30').getTime(),
+		projectId: 'project-123',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
 	},
 ];
 
-// ─────────────────────────────── TESTS ───────────────────────────────
+const mockDispatch = vi.fn();
+const mockSetIsOpen = vi.fn();
+
+const createMockState = (): RootState =>
+	({
+		layers: {
+			ids: mockLayers.map((l) => l.id),
+			entities: Object.fromEntries(mockLayers.map((l) => [l.id, l])),
+			activeId: mockLayers[0].id,
+			projectId: 'project-123',
+			loading: 'succeeded' as const,
+			error: null,
+		},
+	}) as RootState;
+
+type SelectorFunc<TResult> = (state: RootState, ...args: string[]) => TResult;
+
 describe('LayersPanel', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		vi.mocked(hooks.useAppDispatch).mockReturnValue(mockDispatch);
-		vi.mocked(hooks.useAppSelector).mockImplementation((selector) => {
-			if (selector.name.includes('selectAll')) return mockLayers;
-			if (selector.name.includes('selectActiveLayer')) return mockLayers[0];
-			return undefined;
-		});
+		vi.mocked(hooks.useAppDispatch).mockReturnValue(mockDispatch as AppDispatch);
+		vi.mocked(hooks.useAppSelector).mockImplementation(
+			<T,>(selector: (state: RootState) => T): T => {
+				const state = createMockState();
+				if (typeof selector === 'function') {
+					const result = selector(state);
+					if (typeof result === 'function') {
+						const projectorFunc = result as SelectorFunc<Layer[]>;
+						return projectorFunc(state, 'project-123') as T;
+					}
+					return result;
+				}
+				return undefined as T;
+			},
+		);
+		mockDispatch.mockImplementation((action: unknown) => action);
 	});
 
-	it('dispatches fetchLayersByProject on mount', () => {
-		render(<LayersPanel projectId="123" setIsOpen={mockSetIsOpen} />);
-		expect(fetchLayersByProject).toHaveBeenCalledWith('123');
+	it('dispatches fetchLayersByProject on mount', async () => {
+		const { fetchLayersByProject } = await import('@/entities/layer/model/slice');
+		render(<LayersPanel projectId="project-123" setIsOpen={mockSetIsOpen} />);
+		expect(fetchLayersByProject).toHaveBeenCalledWith('project-123');
 		expect(mockDispatch).toHaveBeenCalledWith({
-			type: 'mock/fetchLayers',
-			payload: '123',
+			type: 'layers/fetchLayersByProject',
+			payload: 'project-123',
 		});
 	});
 
 	it('renders toggle button (panel closed by default)', () => {
-		render(<LayersPanel projectId="123" setIsOpen={mockSetIsOpen} />);
+		render(<LayersPanel projectId="project-123" setIsOpen={mockSetIsOpen} />);
 		const btn = screen.getByRole('button', { name: /open layers panel/i });
 		expect(btn).toBeInTheDocument();
+		expect(btn).toHaveTextContent('Open Panel');
 	});
 
-	it('opens and closes the panel', () => {
-		render(<LayersPanel projectId="123" setIsOpen={mockSetIsOpen} />);
-		fireEvent.click(screen.getByRole('button', { name: /open layers panel/i }));
-		expect(screen.getByText(/layers/i)).toBeInTheDocument();
-		fireEvent.click(screen.getByRole('button', { name: /close layers panel/i }));
-		expect(screen.queryByText(/layers/i)).not.toBeInTheDocument();
+	it('opens and closes the panel', async () => {
+		render(<LayersPanel projectId="project-123" setIsOpen={mockSetIsOpen} />);
+		const openBtn = screen.getByRole('button', { name: /open layers panel/i });
+		fireEvent.click(openBtn);
+		await waitFor(() => {
+			expect(screen.getByText(/layers/i)).toBeInTheDocument();
+		});
+		expect(mockSetIsOpen).toHaveBeenCalledWith(true);
+		const closeBtn = screen.getByRole('button', { name: /close layers panel/i });
+		fireEvent.click(closeBtn);
+		await waitFor(() => {
+			expect(screen.queryByText(/layers/i)).not.toBeInTheDocument();
+		});
+		expect(mockSetIsOpen).toHaveBeenCalledWith(false);
 	});
 
-	it('dispatches createLayer when Add Layer clicked', () => {
-		render(<LayersPanel projectId="123" setIsOpen={mockSetIsOpen} />);
+	it('dispatches createLayer when Add Layer clicked', async () => {
+		const { createLayer } = await import('@/entities/layer/model/slice');
+		render(<LayersPanel projectId="project-123" setIsOpen={mockSetIsOpen} />);
 		fireEvent.click(screen.getByRole('button', { name: /open layers panel/i }));
+		await waitFor(() => {
+			expect(screen.getByTestId('mock-add-layer-btn')).toBeInTheDocument();
+		});
 		const addBtn = screen.getByTestId('mock-add-layer-btn');
 		fireEvent.click(addBtn);
-		expect(createLayer).toHaveBeenCalledWith({ projectId: '123' });
-		expect(mockDispatch).toHaveBeenCalled();
+		expect(createLayer).toHaveBeenCalledWith({ projectId: 'project-123' });
+		expect(mockDispatch).toHaveBeenCalledWith({
+			type: 'layers/createLayer',
+			payload: { projectId: 'project-123' },
+		});
 	});
 
-	it('renders layer list via LayerItem mock', () => {
-		render(<LayersPanel projectId="123" setIsOpen={mockSetIsOpen} />);
+	it('renders layer list via LayerItem mock', async () => {
+		render(<LayersPanel projectId="project-123" setIsOpen={mockSetIsOpen} />);
+		fireEvent.click(screen.getByRole('button', { name: /open layers panel/i }));
+		await waitFor(() => {
+			const items = screen.getAllByTestId('mock-layer-item');
+			expect(items).toHaveLength(2);
+		});
+		const items = screen.getAllByTestId('mock-layer-item');
+		expect(items[0]).toHaveTextContent('Foreground');
+		expect(items[1]).toHaveTextContent('Background');
+	});
+
+	it('displays active layer correctly', async () => {
+		render(<LayersPanel projectId="project-123" setIsOpen={mockSetIsOpen} />);
+		fireEvent.click(screen.getByRole('button', { name: /open layers panel/i }));
+		await waitFor(() => {
+			const activeItem = screen.getByText(/background.*\(active\)/i);
+			expect(activeItem).toBeInTheDocument();
+		});
+	});
+
+	it('renders opacity slider with active layer opacity', async () => {
+		render(<LayersPanel projectId="project-123" setIsOpen={mockSetIsOpen} />);
+		fireEvent.click(screen.getByRole('button', { name: /open layers panel/i }));
+		await waitFor(() => {
+			const opacitySlider = screen.getByTestId('mock-opacity-slider');
+			expect(opacitySlider).toHaveTextContent('Opacity: 1');
+		});
+	});
+
+	it('calls setIsOpen callback when panel state changes', async () => {
+		render(<LayersPanel projectId="project-123" setIsOpen={mockSetIsOpen} />);
+		fireEvent.click(screen.getByRole('button', { name: /open layers panel/i }));
+		await waitFor(() => {
+			expect(mockSetIsOpen).toHaveBeenCalledWith(true);
+		});
+		const closeButton = screen.getByRole('button', { name: /close panel/i });
+		fireEvent.click(closeButton);
+		await waitFor(() => {
+			expect(mockSetIsOpen).toHaveBeenCalledWith(false);
+		});
+	});
+
+	it('sorts layers by zIndex in descending order', async () => {
+		render(<LayersPanel projectId="project-123" setIsOpen={mockSetIsOpen} />);
+		fireEvent.click(screen.getByRole('button', { name: /open layers panel/i }));
+		await waitFor(() => {
+			const items = screen.getAllByTestId('mock-layer-item');
+			expect(items[0]).toHaveAttribute('data-layer-id', 'layer-2');
+			expect(items[1]).toHaveAttribute('data-layer-id', 'layer-1');
+		});
+	});
+
+	it('uses memoized selector from makeSelectByProject', async () => {
+		const { makeSelectByProject } = await import('@/entities/layer/model/selectors');
+		render(<LayersPanel projectId="project-123" setIsOpen={mockSetIsOpen} />);
+		expect(makeSelectByProject).toHaveBeenCalled();
 		fireEvent.click(screen.getByRole('button', { name: /open layers panel/i }));
 		const items = screen.getAllByTestId('mock-layer-item');
 		expect(items).toHaveLength(2);

--- a/src/entities/layer/ui/components/OpacitySlider.tsx
+++ b/src/entities/layer/ui/components/OpacitySlider.tsx
@@ -1,12 +1,12 @@
 import type { Layer } from '@/shared/types';
 
 interface OpacitySliderProps {
-	activeLayer: Layer | undefined;
+	activeLayer: Layer | null;
 	onOpacityChange: (id: string, value: number) => void;
 }
 
 export function OpacitySlider({ activeLayer, onOpacityChange }: OpacitySliderProps) {
-	const active = activeLayer;
+	const active = activeLayer ?? undefined;
 	const opacityValue = active?.opacity ?? 1;
 
 	return (
@@ -48,7 +48,9 @@ export function OpacitySlider({ activeLayer, onOpacityChange }: OpacitySliderPro
                     "
 					// Uses a linear gradient to visually represent the progress fill of the slider track.
 					style={{
-						background: `linear-gradient(to right, #4f46e5 ${opacityValue * 100}%, #e5e7eb ${opacityValue * 100}%)`,
+						background: `linear-gradient(to right, #4f46e5 ${
+							opacityValue * 100
+						}%, #e5e7eb ${opacityValue * 100}%)`,
 					}}
 				/>
 			</div>

--- a/src/entities/line/model/slice.ts
+++ b/src/entities/line/model/slice.ts
@@ -16,22 +16,16 @@ const lineSlice = createSlice({
 	name: 'line',
 	initialState,
 	reducers: {
-		activateLine(state) {
-			state.active = true;
-		},
-		deactivateLine(state) {
-			state.active = false;
-		},
 		setLineColor(state, action: PayloadAction<string>) {
 			state.color = action.payload;
 		},
 		setLineThickness(state, action: PayloadAction<number>) {
 			state.thickness = action.payload;
 		},
+		resetLineState: () => initialState,
 	},
 });
 
-export const { activateLine, deactivateLine, setLineColor, setLineThickness } =
-	lineSlice.actions;
+export const { setLineColor, setLineThickness, resetLineState } = lineSlice.actions;
 
 export const lineReducer = lineSlice.reducer;

--- a/src/entities/shape/model/slice.ts
+++ b/src/entities/shape/model/slice.ts
@@ -34,10 +34,16 @@ const shapeSlice = createSlice({
 		setShapeThickness(state, action: PayloadAction<number>) {
 			state.thickness = action.payload;
 		},
+		resetShapeState: () => initialState,
 	},
 });
 
-export const { setShapeType, setShapeFill, setShapeStroke, setShapeThickness } =
-	shapeSlice.actions;
+export const {
+	setShapeType,
+	setShapeFill,
+	setShapeStroke,
+	setShapeThickness,
+	resetShapeState,
+} = shapeSlice.actions;
 
 export const shapeReducer = shapeSlice.reducer;

--- a/src/pages/editor/ui/EditorPage.tsx
+++ b/src/pages/editor/ui/EditorPage.tsx
@@ -1,15 +1,85 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import { projectsSelectors } from '@/entities/project/model';
 import { EditorViewport } from '@/widgets/viewport/model';
+import { LAYER } from '@/shared/constants';
 import { LayersPanel } from '@/entities/layer/ui';
+import { layerService } from '@/entities/layer/model';
+import { layersSelectors } from '@/entities/layer/model/selectors';
+import { fetchLayersByProject, setActiveLayerId } from '@/entities/layer/model/slice';
+import { resetEditorState } from '@/entities/editor/model/slice';
+import { resetBrushState } from '@/entities/brush/model/slice';
+import { resetLineState } from '@/entities/line/model/slice';
+import { resetShapeState } from '@/entities/shape/model/slice';
+import { resetEraserState } from '@/entities/eraser/model/slice';
+import { store } from '@/store';
 
 export const EditorPage = () => {
 	const [isLayersOpen, setIsLayersOpen] = useState(false);
-	const projectId = 'current-project';
+	const dispatch = useAppDispatch();
+	const activeProject = useAppSelector(projectsSelectors.selectActiveProject);
+
+	// Protect from double initialization in StrictMode
+	const initRef = useRef(false);
+
+	useEffect(() => {
+		return () => {
+			dispatch(resetEditorState());
+			dispatch(resetBrushState());
+			dispatch(resetLineState());
+			dispatch(resetShapeState());
+			dispatch(resetEraserState());
+		};
+	}, [dispatch]);
+	useEffect(() => {
+		const pid = activeProject?.id;
+		if (!pid || initRef.current) return;
+		initRef.current = true;
+
+		(async () => {
+			//  Load existing layers
+			const { layers: loaded } = await dispatch(fetchLayersByProject(pid)).unwrap();
+
+			// If this is first open — atomically create base layer
+			if (loaded.length === 0) {
+				const created = await layerService.ensureBaseLayer(
+					pid,
+					`${LAYER.NEW_LAYER} 1`,
+				);
+
+				//  Do NOT call createLayer again — ensureBaseLayer already wrote to DB
+				if (created) {
+					// just sync Redux with current Dexie state
+					await dispatch(fetchLayersByProject(pid)).unwrap();
+				}
+			}
+
+			// Pick top layer as active
+			const allLayers = layersSelectors.selectByProject(store.getState(), pid);
+			if (allLayers.length > 0) {
+				const topLayer = allLayers.sort((a, b) => b.zIndex - a.zIndex)[0];
+				dispatch(setActiveLayerId(topLayer.id));
+			}
+		})();
+	}, [dispatch, activeProject?.id]);
+
+	if (!activeProject) {
+		return (
+			<div className="flex items-center justify-center h-screen text-gray-500">
+				No active project selected.
+			</div>
+		);
+	}
 
 	return (
 		<div className="relative h-screen w-screen bg-gray-50 dark:bg-gray-950 overflow-hidden">
-			<EditorViewport isLayersOpen={isLayersOpen} />
-			<LayersPanel projectId={projectId} setIsOpen={setIsLayersOpen} />
+			<EditorViewport
+				isLayersOpen={isLayersOpen}
+				projectId={activeProject.id}
+				width={activeProject.width}
+				height={activeProject.height}
+			/>
+			<LayersPanel projectId={activeProject.id} setIsOpen={setIsLayersOpen} />
 		</div>
 	);
 };

--- a/src/shared/lib/db/dexie.ts
+++ b/src/shared/lib/db/dexie.ts
@@ -1,5 +1,5 @@
 import Dexie, { type Table } from 'dexie';
-import type { Layer, Project } from '@/shared/types';
+import type { Layer, Project, ProjectViewState } from '@/shared/types';
 
 type LegacyProject = Omit<Project, 'width' | 'height'> &
 	Partial<Pick<Project, 'width' | 'height'>>;
@@ -7,20 +7,21 @@ type LegacyProject = Omit<Project, 'width' | 'height'> &
 export class EditorDB extends Dexie {
 	projects!: Table<Project, string>;
 	layers!: Table<Layer, string>;
+	viewStates!: Table<ProjectViewState, string>;
 
-	public constructor() {
+	constructor() {
 		super('EditorDB');
 
 		this.version(1).stores({
 			projects: 'id, name, createdAt, updatedAt',
 		});
+
 		this.version(2)
 			.stores({
 				projects: 'id, name, width, height, createdAt, updatedAt',
 			})
 			.upgrade(async (tx) => {
 				const table = tx.table<LegacyProject, string>('projects');
-
 				await table.toCollection().modify((project) => {
 					if (project.width === undefined) project.width = 800;
 					if (project.height === undefined) project.height = 600;
@@ -28,11 +29,16 @@ export class EditorDB extends Dexie {
 			});
 
 		this.version(3).stores({
-			layers: 'id, projectId, [projectId+zIndex]',
+			layers: 'id, projectId, name, zIndex, visible, opacity, createdAt, updatedAt, snapshot',
+		});
+
+		this.version(4).stores({
+			viewStates: 'projectId',
 		});
 
 		this.projects = this.table('projects');
 		this.layers = this.table('layers');
+		this.viewStates = this.table('viewStates');
 	}
 }
 

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -15,4 +15,14 @@ export interface Layer {
 	zIndex: number;
 	createdAt: number;
 	updatedAt: number;
+	snapshot?: string;
+}
+
+export interface ProjectViewState {
+	projectId: string;
+	scale: number;
+	offsetX: number;
+	offsetY: number;
+	showGrid: boolean;
+	snapshot?: string; // base64 PNG preview
 }

--- a/src/widgets/canvas/__tests__/DrawCanvas.test.tsx
+++ b/src/widgets/canvas/__tests__/DrawCanvas.test.tsx
@@ -3,7 +3,9 @@ import { DrawCanvas } from '@/widgets/canvas/ui/DrawCanvas';
 
 describe('DrawCanvas', () => {
 	it('renders correctly with width and height', () => {
-		const { getByTestId } = render(<DrawCanvas width={500} height={300} />);
+		const { getByTestId } = render(
+			<DrawCanvas width={500} height={300} isPanning={false} />,
+		);
 		const canvas = getByTestId('draw-canvas') as HTMLCanvasElement;
 
 		expect(canvas).toBeInTheDocument();
@@ -23,6 +25,7 @@ describe('DrawCanvas', () => {
 				onPointerDown={onDown}
 				onPointerMove={onMove}
 				onPointerUp={onUp}
+				isPanning={false}
 			/>,
 		);
 
@@ -37,7 +40,9 @@ describe('DrawCanvas', () => {
 	});
 
 	it('renders safely without handlers', () => {
-		const { getByTestId } = render(<DrawCanvas width={100} height={100} />);
+		const { getByTestId } = render(
+			<DrawCanvas width={100} height={100} isPanning={false} />,
+		);
 		const canvas = getByTestId('draw-canvas') as HTMLCanvasElement;
 
 		expect(canvas).toBeInTheDocument();

--- a/src/widgets/canvas/model/index.ts
+++ b/src/widgets/canvas/model/index.ts
@@ -1,2 +1,3 @@
 export * from '../ui/DrawCanvas';
 export * from '../ui/GridCanvas';
+export * from '../ui/LayerStack';

--- a/src/widgets/canvas/ui/DrawCanvas.tsx
+++ b/src/widgets/canvas/ui/DrawCanvas.tsx
@@ -6,11 +6,12 @@ interface DrawCanvasProps {
 	onPointerDown?: (e: React.PointerEvent<HTMLCanvasElement>) => void;
 	onPointerMove?: (e: React.PointerEvent<HTMLCanvasElement>) => void;
 	onPointerUp?: (e: React.PointerEvent<HTMLCanvasElement>) => void;
+	isPanning: boolean;
 	'data-testid'?: string;
 }
 
 /**
- * Interactive drawing layer for active tools (brush, line, etc.)
+ * Interactive drawing surface for active tools (brush, eraser, line, shape)
  */
 export const DrawCanvas = forwardRef<HTMLCanvasElement, DrawCanvasProps>(
 	(
@@ -20,6 +21,7 @@ export const DrawCanvas = forwardRef<HTMLCanvasElement, DrawCanvasProps>(
 			onPointerDown,
 			onPointerMove,
 			onPointerUp,
+			isPanning = false,
 			'data-testid': testId = 'draw-canvas',
 		},
 		ref,
@@ -30,7 +32,10 @@ export const DrawCanvas = forwardRef<HTMLCanvasElement, DrawCanvasProps>(
 				role="presentation"
 				width={width}
 				height={height}
-				className="absolute inset-0 cursor-crosshair"
+				className={`absolute inset-0 ${isPanning ? 'cursor-grabbing' : 'cursor-crosshair'}`}
+				style={{
+					zIndex: 1000,
+				}}
 				onPointerDown={onPointerDown}
 				onPointerMove={onPointerMove}
 				onPointerUp={onPointerUp}

--- a/src/widgets/canvas/ui/LayerStack.tsx
+++ b/src/widgets/canvas/ui/LayerStack.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import type { Layer } from '@/shared/types';
+
+interface LayerStackProps {
+	layers: Layer[];
+	width: number;
+	height: number;
+	bindCanvasRef: (id: string) => (el: HTMLCanvasElement | null) => void;
+	activeLayerId?: string | null;
+}
+
+/**
+ * Renders all project layers as static canvases.
+ * These canvases are now non-interactive (pointer-events: none),
+ * so pointer input passes through to the DrawCanvas above.
+ */
+export const LayerStack: React.FC<LayerStackProps> = ({
+	layers,
+	width,
+	height,
+	bindCanvasRef,
+	activeLayerId,
+}) => {
+	return (
+		<>
+			{layers.map((layer) => {
+				const isActive = layer.id === activeLayerId;
+				return (
+					<canvas
+						key={layer.id}
+						ref={bindCanvasRef(layer.id)}
+						width={width}
+						height={height}
+						style={{
+							position: 'absolute',
+							inset: 0,
+							opacity: layer.opacity,
+							display: layer.visible ? 'block' : 'none',
+							pointerEvents: 'none',
+							// Soft aura for the active layer
+							boxShadow: isActive
+								? '0 0 10px 3px rgba(59,130,246,0.5)'
+								: 'none',
+							transition: 'box-shadow 0.25s ease-in-out',
+							backgroundColor: 'transparent',
+						}}
+					/>
+				);
+			})}
+		</>
+	);
+};

--- a/src/widgets/viewport/__tests__/ViewportRepository.test.ts
+++ b/src/widgets/viewport/__tests__/ViewportRepository.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { db } from '@/shared/lib/db';
+import type { ProjectViewState } from '@/shared/types';
+import { ViewportRepository } from '@/widgets/viewport/api';
+
+// Mock Dexie database
+vi.mock('@/shared/lib/db', () => {
+	const map = new Map<string, ProjectViewState>();
+	return {
+		db: {
+			table: vi.fn(() => ({
+				get: vi.fn((id: string) => Promise.resolve(map.get(id))),
+				put: vi.fn((state: ProjectViewState) => {
+					map.set(state.projectId, state);
+					return Promise.resolve();
+				}),
+			})),
+		},
+	};
+});
+
+describe('ViewportRepository', () => {
+	const sample: ProjectViewState = {
+		showGrid: false,
+		projectId: 'p1',
+		scale: 1.2,
+		offsetX: 100,
+		offsetY: 200,
+	};
+
+	beforeEach(async () => {
+		// clear table
+		const table = db.table<ProjectViewState>('viewStates');
+		await table.put(sample);
+	});
+
+	it('should save state to Dexie table', async () => {
+		const newState: ProjectViewState = {
+			showGrid: false,
+			projectId: 'p2',
+			scale: 0.8,
+			offsetX: -50,
+			offsetY: 30,
+		};
+
+		await ViewportRepository.save(newState);
+		const result = await ViewportRepository.get('p2');
+
+		expect(result).toEqual(newState);
+	});
+
+	it('should get existing state by projectId', async () => {
+		const result = await ViewportRepository.get('p1');
+
+		expect(result).toBeDefined();
+		expect(result?.scale).toBe(1.2);
+		expect(result?.offsetX).toBe(100);
+		expect(result?.offsetY).toBe(200);
+	});
+
+	it('should overwrite existing state if saved again', async () => {
+		const updated: ProjectViewState = {
+			...sample,
+			showGrid: false,
+			scale: 2,
+			offsetX: 300,
+			offsetY: 400,
+		};
+
+		await ViewportRepository.save(updated);
+		const result = await ViewportRepository.get('p1');
+
+		expect(result).toEqual(updated);
+	});
+});

--- a/src/widgets/viewport/api/index.ts
+++ b/src/widgets/viewport/api/index.ts
@@ -1,0 +1,1 @@
+export * from './viewport.repository';

--- a/src/widgets/viewport/api/viewport.repository.ts
+++ b/src/widgets/viewport/api/viewport.repository.ts
@@ -1,0 +1,15 @@
+import { db } from '@/shared/lib/db';
+import type { ProjectViewState } from '@/shared/types';
+
+/**
+ * Simple repository for saving / loading the viewport state per project.
+ */
+export const ViewportRepository = {
+	async get(projectId: string): Promise<ProjectViewState | undefined> {
+		return db.table<ProjectViewState>('viewStates').get(projectId);
+	},
+
+	async save(state: ProjectViewState): Promise<void> {
+		await db.table<ProjectViewState>('viewStates').put(state);
+	},
+};

--- a/src/widgets/viewport/ui/EditorViewport.tsx
+++ b/src/widgets/viewport/ui/EditorViewport.tsx
@@ -1,6 +1,5 @@
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { useAppSelector } from '@/store/hooks';
-import { projectsSelectors } from '@/entities/project/model';
 import { useViewportControls } from '../hooks';
 import { ViewportControls } from './ViewportControls';
 import { ToolBar } from '@/widgets/toolbar/model';
@@ -9,11 +8,9 @@ import { LineTool, useLineDraw } from '@/entities/line/model';
 import { ShapeTool, useShapeDraw } from '@/entities/shape/model';
 import { EraserTool, useEraserDraw } from '@/entities/eraser/model';
 import { selectActiveTool } from '@/entities/editor/model/selectors';
-import { DrawCanvas, GridCanvas } from '@/widgets/canvas/model';
-
-// ─── Constants ────────────────────────────────────────────
-const CANVAS_WIDTH = 1200;
-const CANVAS_HEIGHT = 800;
+import { DrawCanvas, GridCanvas, LayerStack } from '@/widgets/canvas/model';
+import { layerService, useLayerCanvases } from '@/entities/layer/model';
+import { layersSelectors, makeSelectByProject } from '@/entities/layer/model/selectors';
 
 // ─── Types ────────────────────────────────────────────────
 type ToolType = 'brush' | 'eraser' | 'line' | 'shape';
@@ -24,54 +21,88 @@ interface ToolHandlers {
 	onPointerUp?: (e: React.PointerEvent<HTMLCanvasElement>) => void;
 }
 
-/**
- * The main editor viewport — manages zooming, panning,
- * and multi-layer canvas composition (grid + drawing).
- */
-export const EditorViewport = ({ isLayersOpen }: { isLayersOpen: boolean }) => {
-	const activeProject = useAppSelector(projectsSelectors.selectActiveProject);
+interface EditorViewportProps {
+	isLayersOpen: boolean;
+	projectId: string;
+	width: number;
+	height: number;
+}
+
+export const EditorViewport = ({
+	isLayersOpen,
+	projectId,
+	width,
+	height,
+}: EditorViewportProps) => {
+	// Take only layers of the current project
+	const selectByProject = useMemo(makeSelectByProject, []);
+	const layersAll = useAppSelector((s) => selectByProject(s, projectId));
+
+	// Sort layers by zIndex (bottom → top)
+	const layers = useMemo(
+		() => [...layersAll].sort((a, b) => a.zIndex - b.zIndex),
+		[layersAll],
+	);
+
+	const activeLayer = useAppSelector(layersSelectors.selectActiveLayer);
 	const activeTool = useAppSelector(selectActiveTool);
-
-	const width = activeProject?.width ?? CANVAS_WIDTH;
-	const height = activeProject?.height ?? CANVAS_HEIGHT;
-
-	const [showGrid, setShowGrid] = useState(true);
-	const toggleGrid = () => setShowGrid((v) => !v);
 
 	const {
 		containerRef,
 		scale: viewportScale,
 		offsetX,
 		offsetY,
+		showGrid,
+		setShowGrid,
 		handleFit,
 		handleReset,
 		onMouseDown,
 		onMouseMove,
 		onMouseUp,
-	} = useViewportControls(width, height);
+		isPanning,
+	} = useViewportControls(width, height, projectId);
 
-	// ─── Layer refs ─────────────────────────────────────────────
+	const toggleGrid = () => setShowGrid((v) => !v);
+
 	const gridRef = useRef<HTMLCanvasElement | null>(null);
 	const drawRef = useRef<HTMLCanvasElement | null>(null);
+
+	// Layer canvases (real DOM elements)
+	const { bindCanvasRef, getCanvas } = useLayerCanvases(
+		layers,
+		projectId,
+		width,
+		height,
+	);
 
 	// ─── Drawing tool hooks ─────────────────────────────────────
 	const brush = useBrushDraw(drawRef);
 	const line = useLineDraw(drawRef);
 	const shape = useShapeDraw(drawRef);
-	const eraser = useEraserDraw(drawRef);
+	const eraser = useEraserDraw(() => (activeLayer ? getCanvas(activeLayer.id) : null));
 
 	// ─── Tool handler map ───────────────────────────────────────
 	const toolHandlers: Partial<Record<ToolType, ToolHandlers>> = useMemo(
-		() => ({
-			brush,
-			line,
-			shape,
-			eraser,
-		}),
-		[brush, eraser, line, shape],
+		() => ({ brush, line, shape, eraser }),
+		[brush, line, shape, eraser],
 	);
 
 	const activeHandlers = activeTool ? toolHandlers[activeTool] : undefined;
+
+	// Save snapshot of the active layer after drawing
+	const handlePointerUp = async (e: React.PointerEvent<HTMLCanvasElement>) => {
+		activeHandlers?.onPointerUp?.(e);
+		if (!activeLayer) return;
+		const target = getCanvas(activeLayer.id);
+		const drawCanvas = drawRef.current;
+		if (target && drawCanvas) {
+			const ctx = target.getContext('2d');
+			ctx?.drawImage(drawCanvas, 0, 0);
+			drawCanvas.getContext('2d')?.clearRect(0, 0, width, height);
+			const snapshot = target.toDataURL('image/png');
+			await layerService.updateLayer({ id: activeLayer.id, changes: { snapshot } });
+		}
+	};
 
 	// ─── JSX ─────────────────────────────────────────────────────
 	return (
@@ -81,13 +112,16 @@ export const EditorViewport = ({ isLayersOpen }: { isLayersOpen: boolean }) => {
 			onMouseDown={onMouseDown}
 			onMouseMove={onMouseMove}
 			onMouseUp={onMouseUp}
-			className="relative w-full h-full bg-gray-100 dark:bg-gray-900 flex items-center justify-center select-none overflow-hidden"
+			className={`relative w-full h-full bg-gray-100 dark:bg-gray-900 flex items-center justify-center select-none overflow-hidden transition-all duration-300 ${
+				isLayersOpen ? 'pr-72' : ''
+			}`}
 		>
 			{/* ───────── CANVAS STACK ───────── */}
 			<div
 				style={{
 					width,
 					height,
+					position: 'relative',
 					transform: `translate(${offsetX}px, ${offsetY}px) scale(${viewportScale})`,
 					transformOrigin: 'center',
 					border: '1px solid rgba(0,0,0,0.2)',
@@ -105,6 +139,15 @@ export const EditorViewport = ({ isLayersOpen }: { isLayersOpen: boolean }) => {
 					background={'#ffffff'}
 				/>
 
+				{/* Static layer canvases */}
+				<LayerStack
+					layers={layers}
+					width={width}
+					height={height}
+					bindCanvasRef={bindCanvasRef}
+					activeLayerId={activeLayer?.id}
+				/>
+
 				{/* Active drawing layer */}
 				<DrawCanvas
 					ref={drawRef}
@@ -112,7 +155,8 @@ export const EditorViewport = ({ isLayersOpen }: { isLayersOpen: boolean }) => {
 					height={height}
 					onPointerDown={activeHandlers?.onPointerDown}
 					onPointerMove={activeHandlers?.onPointerMove}
-					onPointerUp={activeHandlers?.onPointerUp}
+					onPointerUp={handlePointerUp}
+					isPanning={isPanning}
 				/>
 			</div>
 


### PR DESCRIPTION
### 📌 Pull Request

#### 🔀 Branch

`layers/feature/layers-dexie`

#### 📝 Description

Implement layer management: integration with Dexie. 

#### ✅ Related Issue

Closes #131

#### 🔍 Checklist

- [x]  integrate layers and Dexie
- [x]  save layers to db
- [x]  drag drop layers 
- [x]  close palette after close editor
- [x]  remove duplicate name layers
- [x] shadow canvas if active layers
- [x]  pointer for eraser  
- [x] add memorize for layers selectors 


#### 📷 Screenshots (if UI)

https://github.com/user-attachments/assets/ab9865c4-5216-49de-8f64-d326346bf7fc


