### PR TITLE
[HOTFIX] Dexie ConstraintError when opening a project on GitHub Pages

### DIFF
--- a/src/entities/history/api/history.repository.ts
+++ b/src/entities/history/api/history.repository.ts
@@ -14,7 +14,7 @@ export const historyRepository = {
 			.sortBy(`${REPOSITORY_FIELDS.TIMESTAMP}`);
 	},
 	async deleteById(id: string): Promise<void> {
-		await historyTable.where('id').equals(id).delete();
+		await historyTable.where(REPOSITORY_FIELDS.ID).equals(id).delete();
 	},
 
 	async deleteAfterIndex(projectId: string, index: number): Promise<void> {

--- a/src/entities/layer/api/layer.repository.ts
+++ b/src/entities/layer/api/layer.repository.ts
@@ -23,7 +23,7 @@ export const layerRepository = {
 	},
 
 	async add(layer: Layer): Promise<void> {
-		await layerTable.add(layer);
+		await layerTable.put(layer);
 	},
 
 	async update(id: string, changes: Partial<Layer>): Promise<void> {

--- a/src/entities/layer/model/layer.service.ts
+++ b/src/entities/layer/model/layer.service.ts
@@ -2,6 +2,7 @@ import { nanoid } from 'nanoid';
 import type { EditorSnapshot, Layer } from '@/shared/types';
 import { layerRepository } from '@/entities/layer/api';
 import { LAYER, LAYER_DEFAULTS, LAYER_ERROR_MESSAGES } from '@/shared/constants';
+import Dexie from 'dexie';
 
 export const layerService = {
 	async getLayers(projectId: string): Promise<Layer[]> {
@@ -68,7 +69,7 @@ export const layerService = {
 	async replaceAll(projectId: string, layers: EditorSnapshot['layers']) {
 		// remove all layers from project
 		await layerRepository.removeByProject(projectId);
-
+		await Dexie.waitFor(Promise.resolve());
 		// add layers from a snapshot
 		for (const l of layers) {
 			await layerRepository.add({

--- a/src/entities/project/api/project.repository.ts
+++ b/src/entities/project/api/project.repository.ts
@@ -24,7 +24,7 @@ export const projectRepository = {
 	},
 
 	async add(project: Project): Promise<void> {
-		await projectTable.add(project);
+		await projectTable.put(project);
 	},
 
 	async update(id: string, changes: Partial<Project>): Promise<void> {

--- a/src/shared/constants/editor.ts
+++ b/src/shared/constants/editor.ts
@@ -22,6 +22,7 @@ export const SHAPES = {
 
 export const REPOSITORY_FIELDS = {
 	PROJECT_ID: 'projectId',
+	ID: 'id',
 	STATE_PROJECT_ID: 'state.projectId',
 	TIMESTAMP: 'timestamp',
 	Z_INDEX: 'zIndex',


### PR DESCRIPTION
Description error:
"Key already exists in the object store. ConstraintError"

Cause:
Dexie .add() operations and a race condition triggered after removeByProject() where IndexedDB has not completed the delete transaction before new records are inserted.

Fix:
Replace all add() calls with put() to avoid primary-key collisions, and add Dexie.waitFor() after layer deletions to prevent race conditions.

Affected modules:

- replaceAll()
- layerRepository
- historyRepository

Fixed in branch:
`hotfix/fix-dexie-constraint`
