### PR TITLE
fix(viewport): floating palettes no longer overlap footer & FPS HUD (…

### DIFF
--- a/src/entities/brush/ui/BrushFloatingPalette.tsx
+++ b/src/entities/brush/ui/BrushFloatingPalette.tsx
@@ -18,7 +18,7 @@ export const BrushFloatingPalette = React.memo(function BrushFloatingPalette() {
 			selectedColor={color}
 			onValueChange={(v) => dispatch(setBrushSize(v))}
 			onColorChange={(c) => dispatch(setBrushColor(c))}
-			position="top-24"
+			position="bottom-19"
 		/>
 	);
 });

--- a/src/entities/eraser/ui/EraserFloatingPalette.tsx
+++ b/src/entities/eraser/ui/EraserFloatingPalette.tsx
@@ -14,7 +14,7 @@ export function EraserFloatingPalette() {
 			values={TOOL_SIZES}
 			selectedValue={size}
 			onValueChange={(v) => dispatch(setEraserSize(v))}
-			position="top-72"
+			position="bottom-43"
 			data-testid-prefix="eraser"
 		/>
 	);

--- a/src/entities/line/ui/LineFloatingPalette.tsx
+++ b/src/entities/line/ui/LineFloatingPalette.tsx
@@ -18,7 +18,7 @@ export const LineFloatingPalette = React.memo(function LineFloatingPalette() {
 			selectedColor={color}
 			onValueChange={(v) => dispatch(setLineThickness(v))}
 			onColorChange={(c) => dispatch(setLineColor(c))}
-			position="top-52"
+			position="bottom-19"
 		/>
 	);
 });

--- a/src/entities/shape/ui/ShapeFloatingPalette.tsx
+++ b/src/entities/shape/ui/ShapeFloatingPalette.tsx
@@ -60,7 +60,7 @@ export const ShapeFloatingPalette = React.memo(function ShapeFloatingPalette() {
 			selectedColor={stroke}
 			onValueChange={handleThicknessChange}
 			onColorChange={handleStrokeChange}
-			position="top-72"
+			position="bottom-8"
 		>
 			<div className="flex items-center justify-between gap-3">
 				{/* ───────── Shape Type Buttons ───────── */}

--- a/src/widgets/toolbar/ui/ToolFloatingPalette.tsx
+++ b/src/widgets/toolbar/ui/ToolFloatingPalette.tsx
@@ -1,5 +1,5 @@
-import { ColorSelector, ValueSelector } from '@/widgets/toolbar/ui';
 import type { ReactNode } from 'react';
+import { ColorSelector, ValueSelector } from '@/widgets/toolbar/ui';
 
 interface ToolFloatingPaletteProps {
 	title: string;
@@ -23,10 +23,11 @@ export function ToolFloatingPalette({
 	selectedColor = '#6B7280',
 	onValueChange,
 	onColorChange,
-	position = 'top-24',
+	position = 'bottom-44',
 	children,
 }: ToolFloatingPaletteProps) {
 	const hasColors = Array.isArray(colors) && colors.length > 0;
+
 	return (
 		<div
 			className={`fixed left-20 ${position} z-40 w-[320px] rounded-2xl border border-gray-200 bg-white shadow-xl p-3 backdrop-blur-sm`}
@@ -48,7 +49,7 @@ export function ToolFloatingPalette({
 				<>
 					<hr className="my-3 h-px bg-gray-100" />
 					<ColorSelector
-						colors={colors!}
+						colors={colors}
 						selectedColor={selectedColor}
 						onChange={onColorChange!}
 						dataPrefix={title.toLowerCase()}


### PR DESCRIPTION
### 📌 Pull Request

#### 🔀 Branch

`fix/ui-floating-pallets-overlap`

#### 📝 Description

fix(viewport): floating palettes no longer overlap footer & FPS HUD

#### ✅ Related Issue

Closes #153
